### PR TITLE
Added BLE and some improvements

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,116 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.6.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 18 22:48:36 EDT 2019
+#Sat Apr 04 20:32:46 BST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/rocketlocator/build.gradle
+++ b/rocketlocator/build.gradle
@@ -25,6 +25,9 @@ android {
         }
     }
 
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -33,6 +36,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.google.android.gms:play-services-maps:16.1.0'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.7.22'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/rocketlocator/build.gradle
+++ b/rocketlocator/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.frankdev.rocketlocator"
-        minSdkVersion 18
+        minSdkVersion 15
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/rocketlocator/build.gradle
+++ b/rocketlocator/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.frankdev.rocketlocator"
-        minSdkVersion 15
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/BleListPreference.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/BleListPreference.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2013 Fran�ois Girard
+ * Contributor: Balazs Mihaly | mihu86
+ *
+ * This file is part of Rocket Finder.
+ *
+ * Rocket Finder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Rocket Finder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Rocket Finder. If not, see <http://www.gnu.org/licenses/>.*/
+
+package com.frankdev.rocketlocator;
+
+import android.app.AlertDialog;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Handler;
+import android.preference.ListPreference;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BleListPreference extends ListPreference {
+
+    private static final String LOG_TAG = "RocketLocatorBLE";
+
+    private Handler handler;
+    private BluetoothAdapter bluetoothAdapter;
+    private BluetoothAdapter.LeScanCallback scanCallback;
+
+    private BleAdapter listAdapter;
+    private final LayoutInflater inflater;
+    private int selectedIndex;
+
+    public BleListPreference(Context context) {
+        super(context);
+        inflater = LayoutInflater.from(context);
+    }
+
+    public BleListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        inflater = LayoutInflater.from(context);
+    }
+
+    @Override
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        handler = new Handler();
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+                scanCallback = new BluetoothAdapter.LeScanCallback() {
+                    @Override
+                    public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
+                        Log.v(LOG_TAG, "Found device: " + device.getAddress());
+                        addDevice(new BleListPreference.Device(device.getAddress(), device.getName()));
+                    }
+                };
+                bluetoothAdapter.startLeScan(scanCallback);
+            }
+        });
+
+        listAdapter = new BleAdapter();
+        builder.setAdapter(listAdapter, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                selectedIndex = which;
+
+                /*
+                 * Clicking on an item simulates the positive button
+                 * click, and dismisses the dialog.
+                 */
+                BleListPreference.this.onClick(dialog, DialogInterface.BUTTON_POSITIVE);
+                dialog.dismiss();
+            }
+        });
+
+        /*
+         * The typical interaction for list-based dialogs is to have
+         * click-on-an-item dismiss the dialog instead of the user having to
+         * press 'Ok'.
+         */
+        builder.setPositiveButton(null, null);
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        bluetoothAdapter.stopLeScan(scanCallback);
+
+        if (positiveResult && selectedIndex >= 0) {
+            String value = listAdapter.getItem(selectedIndex).getAddress();
+            Log.d(LOG_TAG, "Selected BLE device: " + value);
+            if (callChangeListener(value)) {
+                setValue(value);
+            }
+        }
+    }
+
+    private void addDevice(Device device) {
+        listAdapter.addDevice(device);
+        listAdapter.notifyDataSetChanged();
+    }
+
+    class BleAdapter extends BaseAdapter {
+
+        private List<Device> devices = new ArrayList<>();
+
+        @Override
+        public int getCount() {
+            return devices.size();
+        }
+
+        @Override
+        public Device getItem(int position) {
+            return devices.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        void addDevice(Device device) {
+            if (!devices.contains(device) && device.getName() != null && !device.getName().isEmpty()) {
+                devices.add(device);
+            }
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            // TODO use ViewHolder
+            View view = convertView != null ? convertView : inflater.inflate(R.layout.listitem_device, parent, false);
+            final Device device = devices.get(position);
+            TextView name = view.findViewById(R.id.device_name);
+
+            if (device.getName() != null && !device.getName().isEmpty()) {
+                name.setText(device.getName());
+            } else {
+                name.setText("N/A");
+            }
+
+            TextView address = view.findViewById(R.id.device_address);
+            address.setText(device.getAddress());
+
+            return view;
+        }
+    }
+
+    static class Device {
+        private String address;
+        private String name;
+
+        Device(String address, String name) {
+            this.address = address;
+            this.name = name;
+        }
+
+        String getAddress() {
+            return address;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Device that = (Device) o;
+
+            return address != null ? address.equals(that.address) : that.address == null;
+        }
+
+        @Override
+        public int hashCode() {
+            return address != null ? address.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "DeviceInfo{" +
+                    "address='" + address + '\'' +
+                    ", name='" + name + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/BluetoothListPreference.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/BluetoothListPreference.java
@@ -28,7 +28,6 @@ import android.os.Build;
 import android.os.Handler;
 import android.preference.ListPreference;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,24 +37,24 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BleListPreference extends ListPreference {
+public class BluetoothListPreference extends ListPreference {
 
-    private static final String LOG_TAG = "RocketLocatorBLE";
+    private static final String LOG_TAG = "RocketLocator";
 
     private Handler handler;
     private BluetoothAdapter bluetoothAdapter;
     private BluetoothAdapter.LeScanCallback scanCallback;
 
-    private BleAdapter listAdapter;
+    private ListAdapter listAdapter;
     private final LayoutInflater inflater;
     private int selectedIndex;
 
-    public BleListPreference(Context context) {
+    public BluetoothListPreference(Context context) {
         super(context);
         inflater = LayoutInflater.from(context);
     }
 
-    public BleListPreference(Context context, AttributeSet attrs) {
+    public BluetoothListPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         inflater = LayoutInflater.from(context);
     }
@@ -74,7 +73,7 @@ public class BleListPreference extends ListPreference {
                         @Override
                         public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
                             SharedHolder.getInstance().getLogs().v(LOG_TAG, "Found device: " + device.getAddress());
-                            addDevice(new BleListPreference.Device(device.getAddress(), device.getName()));
+                            addDevice(new BluetoothListPreference.Device(device.getAddress(), device.getName()));
                         }
                     };
                     bluetoothAdapter.startLeScan(scanCallback);
@@ -87,7 +86,7 @@ public class BleListPreference extends ListPreference {
             }
         });
 
-        listAdapter = new BleAdapter();
+        listAdapter = new ListAdapter();
         builder.setAdapter(listAdapter, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -97,7 +96,7 @@ public class BleListPreference extends ListPreference {
                  * Clicking on an item simulates the positive button
                  * click, and dismisses the dialog.
                  */
-                BleListPreference.this.onClick(dialog, DialogInterface.BUTTON_POSITIVE);
+                BluetoothListPreference.this.onClick(dialog, DialogInterface.BUTTON_POSITIVE);
                 dialog.dismiss();
             }
         });
@@ -131,7 +130,7 @@ public class BleListPreference extends ListPreference {
         listAdapter.notifyDataSetChanged();
     }
 
-    class BleAdapter extends BaseAdapter {
+    class ListAdapter extends BaseAdapter {
 
         private List<Device> devices = new ArrayList<>();
 

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/MainActivity.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/MainActivity.java
@@ -26,7 +26,9 @@ import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 
+import org.broeuschmeul.android.gps.bluetooth.provider.BleBluetoothGpsManager;
 import org.broeuschmeul.android.gps.bluetooth.provider.BluetoothGpsManager;
+import org.broeuschmeul.android.gps.bluetooth.provider.ClassicBluetoothGpsManager;
 
 import com.frankdev.rocketlocator.TouchableWrapper.OnMapMoveListener;
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -302,7 +304,11 @@ public class MainActivity extends FragmentActivity implements
 
         BluetoothGpsManager blueGpsMan = SharedHolder.getInstance().getBlueGpsMan();
         if (blueGpsMan == null) {
-            blueGpsMan = new BluetoothGpsManager(getBaseContext(), deviceAddress, 50);
+            if (sharedPreferences.getBoolean(SettingsActivity.PREF_USE_BLE, false)) {
+                blueGpsMan = new BleBluetoothGpsManager();
+            } else {
+                blueGpsMan = new ClassicBluetoothGpsManager(getBaseContext(), deviceAddress, 50);
+            }
             SharedHolder.getInstance().setBlueGpsMan(blueGpsMan);
             blueGpsMan.addObserver(this);
             /*

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/MainActivity.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/MainActivity.java
@@ -48,6 +48,8 @@ import com.google.android.gms.maps.model.TileOverlayOptions;
 
 import android.Manifest;
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationManager;
@@ -73,6 +75,7 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentActivity;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
@@ -86,6 +89,7 @@ import android.widget.ToggleButton;
 public class MainActivity extends FragmentActivity implements
         OnMyLocationChangeListener, SensorEventListener, Observer, OnMapMoveListener, OnMapReadyCallback {
 
+    public static final String GPS_REINIT = "gps_reinit";
     private final int MY_PERMISSIONS_REQUEST_FINE_LOCATION = 1;
     private final int MY_PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 2;
     private final String mapCacheFolder = "mapCache/";
@@ -247,6 +251,13 @@ public class MainActivity extends FragmentActivity implements
         beepEnabled = false;
         radarBeepThread radarBeep = new radarBeepThread();
         radarBeep.start();
+
+        LocalBroadcastManager.getInstance(getApplicationContext()).registerReceiver(new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                initBluetoothGPS();
+            }
+        }, new IntentFilter(GPS_REINIT));
     }
 
     private void checkBluetoothEnabled() {
@@ -305,7 +316,7 @@ public class MainActivity extends FragmentActivity implements
         BluetoothGpsManager blueGpsMan = SharedHolder.getInstance().getBlueGpsMan();
         if (blueGpsMan == null) {
             if (sharedPreferences.getBoolean(SettingsActivity.PREF_USE_BLE, false)) {
-                blueGpsMan = new BleBluetoothGpsManager();
+                blueGpsMan = new BleBluetoothGpsManager(getBaseContext(), deviceAddress, 20);
             } else {
                 blueGpsMan = new ClassicBluetoothGpsManager(getBaseContext(), deviceAddress, 50);
             }

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/ObservableLogs.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/ObservableLogs.java
@@ -65,6 +65,11 @@ public class ObservableLogs extends Observable {
 		Log.v(tag, msg);
 		AddToLogs(msg);
 	}
+
+	public void w(String tag, String msg){
+		Log.w(tag, msg);
+		AddToLogs(msg);
+	}
 	
 	public void appendLogFile(String text) {
 		File logFile = new File(logDirectory + logFileName);

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/SettingsActivity.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/SettingsActivity.java
@@ -22,6 +22,7 @@ import android.app.AlertDialog;
 import android.bluetooth.BluetoothAdapter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
@@ -33,6 +34,7 @@ import android.view.View;
 
 public class SettingsActivity extends PreferenceActivity implements OnPreferenceChangeListener, OnSharedPreferenceChangeListener{
 
+	public static final String PREF_USE_BLE = "ble";
 	public static final String PREF_BLUETOOTH_DEVICE = "bluetoothDevice";
 	public static final String PREF_ABOUT = "about";
 	public static final String PREF_LOGS_ENABLED = "logsEnabled";
@@ -59,6 +61,9 @@ public class SettingsActivity extends PreferenceActivity implements OnPreference
 				return true;
 			}
 		});
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        	findPreference(SettingsActivity.PREF_USE_BLE).setEnabled(false);
+		}
 	}
 
 	@Override

--- a/rocketlocator/src/main/java/com/frankdev/rocketlocator/SettingsActivity.java
+++ b/rocketlocator/src/main/java/com/frankdev/rocketlocator/SettingsActivity.java
@@ -43,12 +43,14 @@ public class SettingsActivity extends PreferenceActivity implements OnPreference
 	public static final String PREF_ABOUT = "about";
 	public static final String PREF_LOGS_ENABLED = "logsEnabled";
 	public static final String PREF_MEASURE_UNIT = "measureUnit";
+	public static final String PREF_EXTERNAL_CACHE = "externalCache";
 
 	private static final String LOG_TAG = "RocketLocator";
 
 	private SharedPreferences sharedPref ;
 	private BluetoothAdapter bluetoothAdapter;
 	private boolean gpsReinit;
+	private boolean extCacheChanged;
 
 	@SuppressWarnings("deprecation")
 	@Override
@@ -136,14 +138,20 @@ public class SettingsActivity extends PreferenceActivity implements OnPreference
 	@Override
 	public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
 
-
-		if (SettingsActivity.PREF_BLUETOOTH_DEVICE.equals(key)){
-			this.gpsReinit = true;
-			this.updateDevicePreferenceSummary();
-		} else if(SettingsActivity.PREF_LOGS_ENABLED.equals(key)){
-			this.enableFileLog(sharedPreferences);
-		} else if(SettingsActivity.PREF_MEASURE_UNIT.equals(key)) {
-			this.updateMeasureUnit();
+		switch (key) {
+			case SettingsActivity.PREF_BLUETOOTH_DEVICE:
+				this.gpsReinit = true;
+				this.updateDevicePreferenceSummary();
+				break;
+			case SettingsActivity.PREF_LOGS_ENABLED:
+				this.enableFileLog(sharedPreferences);
+				break;
+			case SettingsActivity.PREF_MEASURE_UNIT:
+				this.updateMeasureUnit();
+				break;
+			case SettingsActivity.PREF_EXTERNAL_CACHE:
+				this.extCacheChanged = true;
+				break;
 		}
 		this.updateDevicePreferenceSummary();
 	}
@@ -173,9 +181,14 @@ public class SettingsActivity extends PreferenceActivity implements OnPreference
 	protected void onDestroy() {
 		super.onDestroy();
 
+		LocalBroadcastManager localBroadcast = LocalBroadcastManager.getInstance(getApplicationContext());
 		if (gpsReinit) {
 			Intent gpsReinit = new Intent(MainActivity.GPS_REINIT);
-			LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(gpsReinit);
+			localBroadcast.sendBroadcast(gpsReinit);
+		}
+		if (extCacheChanged) {
+			Intent cacheReload = new Intent(MainActivity.CACHE_RELOAD);
+			localBroadcast.sendBroadcast(cacheReload);
 		}
 	}
 

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BleBluetoothGpsManager.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BleBluetoothGpsManager.java
@@ -18,18 +18,39 @@
 
 package org.broeuschmeul.android.gps.bluetooth.provider;
 
-import java.util.Observable;
 
-public abstract class BluetoothGpsManager extends Observable {
-    public abstract int getDisableReason();
+import android.annotation.TargetApi;
+import android.os.Build;
 
-    public abstract boolean isEnabled();
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class BleBluetoothGpsManager extends BluetoothGpsManager {
+    @Override
+    public int getDisableReason() {
+        return 0;
+    }
 
-    public abstract boolean enable();
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 
-    public abstract void startConnectThread();
+    @Override
+    public boolean enable() {
+        return false;
+    }
 
-    public abstract void disable(int reasonId);
+    @Override
+    public void startConnectThread() {
 
-    public abstract void disable(boolean restart);
+    }
+
+    @Override
+    public void disable(int reasonId) {
+
+    }
+
+    @Override
+    public void disable(boolean restart) {
+
+    }
 }

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BleBluetoothGpsManager.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BleBluetoothGpsManager.java
@@ -20,37 +20,170 @@ package org.broeuschmeul.android.gps.bluetooth.provider;
 
 
 import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattService;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
+import com.frankdev.rocketlocator.SharedHolder;
+
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public class BleBluetoothGpsManager extends BluetoothGpsManager {
+    // currently "FFE0", for receiving standard NMEA sentences
+    // maybe the standard "1819" would require different implementation
+    private static final UUID UUID_RW_SERVICE = UUID.fromString("0000ffe0-0000-1000-8000-00805f9b34fb");
+    private static final UUID UUID_RW_CHARACTERISTIC = UUID.fromString("0000ffe1-0000-1000-8000-00805f9b34fb");
+
+    /**
+     * Tag used for log messages
+     */
+    private static final String LOG_TAG = "BlueGPS";
+
+    private final Context context;
+    private final String deviceAddress;
+    private final int maxRetries;
+    private AtomicInteger retries = new AtomicInteger(0);
+    private volatile boolean enabled;
+    private AtomicBoolean starting = new AtomicBoolean();
+    private BluetoothDevice device;
+    private BluetoothGatt gatt;
+    private Handler uiHandler;
+
+    public BleBluetoothGpsManager(Context context, String deviceAddress, int maxRetries) {
+        if (deviceAddress == null || deviceAddress.trim().isEmpty()) {
+            throw new IllegalArgumentException("Device address cannot be empty.");
+        }
+
+        this.context = context;
+        this.deviceAddress = deviceAddress;
+        this.maxRetries = maxRetries;
+        uiHandler = new Handler(Looper.getMainLooper());
+    }
+
     @Override
     public int getDisableReason() {
+        // not used
         return 0;
     }
 
     @Override
     public boolean isEnabled() {
-        return false;
+        return enabled;
     }
 
     @Override
-    public boolean enable() {
-        return false;
-    }
-
-    @Override
-    public void startConnectThread() {
-
+    public void enable() {
+        if (!enabled && starting.compareAndSet(false, true)) {
+            enabled = true;
+            BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
+            device = adapter.getRemoteDevice(deviceAddress);
+            gatt = device.connectGatt(context, false, new GpsCallback());
+        } else {
+            SharedHolder.getInstance().getLogs().w(LOG_TAG, "Manager already enabled or starting.");
+        }
     }
 
     @Override
     public void disable(int reasonId) {
-
+        // reason id not used - just disable
+        disable(false);
     }
 
     @Override
     public void disable(boolean restart) {
+        enabled = false;
+        starting.set(false);
+
+        if (gatt != null) {
+
+            BluetoothGattService service = gatt.getService(UUID_RW_SERVICE);
+            if (service != null) {
+                gatt.setCharacteristicNotification(service.getCharacteristic(UUID_RW_CHARACTERISTIC), false);
+            }
+            gatt.disconnect();
+            gatt.close();
+        }
+
+        if (restart) {
+            enable();
+        }
+    }
+
+    class GpsCallback extends BluetoothGattCallback {
+
+        @Override
+        public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {
+            switch (newState) {
+                case BluetoothGatt.STATE_CONNECTED:
+                    starting.set(false);
+                    SharedHolder.getInstance().getLogs().d(LOG_TAG,"Connected to BLE device: " +
+                            gatt.getDevice().getName() + " (" + gatt.getDevice().getAddress() + ")");
+                    gatt.discoverServices();
+                    break;
+                case BluetoothProfile.STATE_DISCONNECTED:
+                    if (starting.get() && retries.getAndIncrement() < maxRetries) {
+                        SharedHolder.getInstance().getLogs().d(LOG_TAG, "Could not connect to BLE, retry...");
+                        device.connectGatt(context, false, new GpsCallback());
+                    } else {
+                        SharedHolder.getInstance().getLogs().d(LOG_TAG, "BLE disconnected.");
+                    }
+                    break;
+            }
+        }
+
+        @Override
+        public void onServicesDiscovered(BluetoothGatt gatt, int status) {
+            // connection fully set up, start to get notifications
+            BluetoothGattService service = gatt.getService(UUID_RW_SERVICE);
+            if (service != null) {
+                gatt.setCharacteristicNotification(service.getCharacteristic(UUID_RW_CHARACTERISTIC), true);
+                uiHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(context,
+                                "BLE GPS connected",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            } else {
+                SharedHolder.getInstance().getLogs().e(LOG_TAG, "BLE service \"FFE0\" not supported!");
+                uiHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        Toast.makeText(context,
+                                "Device does not support BLE service \"FFE0\"",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void onCharacteristicChanged(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {
+            try {
+                String message = new String(characteristic.getValue(), "US-ASCII"); // StandardCharsets.US_ASCII
+                SharedHolder.getInstance().getLogs().v(LOG_TAG, "Received: " + message);
+                if (message != null && !message.isEmpty()) {
+                    notifyNmeaSentence(message);
+                }
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalStateException("Standard ASCII not known...");
+            }
+        }
 
     }
+
 }

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BluetoothGpsManager.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/BluetoothGpsManager.java
@@ -18,18 +18,51 @@
 
 package org.broeuschmeul.android.gps.bluetooth.provider;
 
+import com.frankdev.rocketlocator.NmeaValues;
+import com.frankdev.rocketlocator.SharedHolder;
+import com.frankdev.rocketlocator.Sounds;
+
+import org.broeuschmeul.android.gps.nmea.util.NmeaParser;
+
 import java.util.Observable;
 
 public abstract class BluetoothGpsManager extends Observable {
+    /**
+     * Tag used for log messages
+     */
+    private static final String LOG_TAG = "BlueGPS";
+    private NmeaParser parser = new NmeaParser(10f);
+
     public abstract int getDisableReason();
 
     public abstract boolean isEnabled();
 
-    public abstract boolean enable();
-
-    public abstract void startConnectThread();
+    public abstract void enable();
 
     public abstract void disable(int reasonId);
 
     public abstract void disable(boolean restart);
+
+    /**
+     * Notifies the reception of a NMEA sentence from the bluetooth GPS to registered NMEA listeners.
+     *
+     * @param nmeaSentence	the complete NMEA sentence received from the bluetooth GPS (i.e. $....*XY where XY is the checksum)
+     */
+    protected void notifyNmeaSentence(final String nmeaSentence) {
+        NmeaValues nmeaValues;
+        try {
+            nmeaValues = parser.parseNmeaSentence(nmeaSentence + "\r\n");
+        } catch (Exception e){
+            SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while parsing NMEA sentence: " + nmeaSentence, e);
+            nmeaValues = null;
+            Sounds.gps_disconnected.start();
+        }
+
+        if (nmeaValues != null && nmeaValues.getCommand() != null &&  nmeaValues.getCommand().equals("GPGGA")) {
+            SharedHolder.getInstance().getLogs().v(LOG_TAG, nmeaSentence);
+            setChanged();
+            notifyObservers(nmeaValues);
+        }
+    }
+
 }

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/ClassicBluetoothGpsManager.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/ClassicBluetoothGpsManager.java
@@ -1,0 +1,523 @@
+/*
+ * Copyright (C) 2010, 2011, 2012 Herbert von Broeuschmeul
+ * Copyright (C) 2010, 2011, 2012 BluetoothGPS4Droid Project
+ * 
+ * This file is part of BluetoothGPS4Droid.
+ *
+ * BluetoothGPS4Droid is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * BluetoothGPS4Droid is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU General Public License
+ *  along with BluetoothGPS4Droid. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.broeuschmeul.android.gps.bluetooth.provider;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.broeuschmeul.android.gps.nmea.util.NmeaParser;
+
+import com.frankdev.rocketlocator.NmeaValues;
+import com.frankdev.rocketlocator.R;
+import com.frankdev.rocketlocator.SharedHolder;
+import com.frankdev.rocketlocator.Sounds;
+
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothSocket;
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Message;
+import android.os.SystemClock;
+import android.widget.Toast;
+
+/**
+ * This class is used to establish and manage the connection with the bluetooth GPS.
+ * 
+ * @author Herbert von Broeuschmeul
+ *
+ */
+@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
+	final Handler handler = new Handler() {
+        @Override
+        public void handleMessage(final Message msgs) {
+        //write your code hear which give error
+        }
+     };
+	
+	public static BluetoothGpsManager instance;
+	/**
+	 * Tag used for log messages
+	 */
+	private static final String LOG_TAG = "BlueGPS";
+
+	/**
+	 * A utility class used to manage the communication with the bluetooth GPS whn the connection has been established.
+	 * It is used to read NMEA data from the GPS or to send SIRF III binary commands or SIRF III NMEA commands to the GPS.
+	 * You should run the main read loop in one thread and send the commands in a separate one.   
+	 * 
+	 * @author Herbert von Broeuschmeul
+	 *
+	 */
+	private class ConnectedGps extends Thread {
+		/**
+		 * GPS bluetooth socket used for communication. 
+		 */
+		private final BluetoothSocket socket;
+		/**
+		 * GPS InputStream from which we read data. 
+		 */
+		private final InputStream gpsInputStream;
+		/**
+		 * GPS output stream to which we send data (SIRF III binary commands). 
+		 */
+		//private final OutputStream out;
+		/**
+		 * GPS output stream to which we send data (SIRF III NMEA commands). 
+		 */
+		//private final PrintStream out2;
+		/**
+		 * A boolean which indicates if the GPS is ready to receive data. 
+		 * In fact we consider that the GPS is ready when it begins to sends data...
+		 */
+		private boolean ready = false;
+
+		public ConnectedGps(BluetoothSocket socket) {
+			this.socket = socket;
+			
+			InputStream tmpIn = null;
+			try {
+				tmpIn = socket.getInputStream();
+			} catch (IOException e) {
+				SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while getting socket streams", e);
+			}	
+			gpsInputStream = tmpIn;
+		}
+	
+
+		@Override
+		public void run() {
+			String sentenseStr;
+			try {
+				
+				BufferedReader reader = new BufferedReader(new InputStreamReader(gpsInputStream,"US-ASCII"));
+				long now = SystemClock.uptimeMillis();
+				long lastRead = now;
+				
+				while((enabled)){
+					if (reader.ready()){
+						sentenseStr = "";
+						//gps connected
+						if(ready == false) {
+							Sounds.gps_connected.start();
+							SharedHolder.getInstance().getLogs().v(LOG_TAG,"GPS Connected");
+							ready = true;
+						}
+						
+						//Start timeout thread for reading gps
+						ExecutorService executor = Executors.newSingleThreadExecutor();
+						ReaderTask readerTask = new ReaderTask(reader);						
+						Future<String> future = executor.submit(readerTask);
+
+				        try {
+				        	//Wait for data and throw TimeoutException if wait for more than 3 sec
+				            sentenseStr = future.get(3, TimeUnit.SECONDS);
+				        } catch (TimeoutException e) {
+				        	SharedHolder.getInstance().getLogs().v(LOG_TAG,"GPS Disconnected");
+							Sounds.gps_disconnected.start();
+				        	ready = false;
+				        } catch (InterruptedException e) {
+							e.printStackTrace();
+						} catch (ExecutionException e) {
+							e.printStackTrace();
+						}
+				        
+				        if(sentenseStr != ""){
+							//SharedHolder.getInstance().getLogs().v(LOG_TAG, "data: "+System.currentTimeMillis()+" "+s);
+							notifyNmeaSentence(sentenseStr + "\r\n");
+				        }
+						lastRead = SystemClock.uptimeMillis();
+					} else {
+						if(now - lastRead > 3000 && ready)
+						{
+				        	SharedHolder.getInstance().getLogs().v(LOG_TAG,"GPS Disconnected");
+							Sounds.gps_disconnected.start();
+							ready = false;		
+							//disable(true);
+							throw new Exception("GPS Disconnected");
+							//enable();
+							//reader.close();
+							//reader = new BufferedReader(new InputStreamReader(gpsInputStream,"US-ASCII"));
+						}
+						/*if(!ready){
+							SharedHolder.getInstance().getLogs().d(LOG_TAG, "data: not ready "+System.currentTimeMillis());
+						}*/
+						SystemClock.sleep(500);
+					}
+					now = SystemClock.uptimeMillis();
+				}
+			} catch (Exception e) {
+				//hasError = true;
+				SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while getting data", e);
+				//setMockLocationProviderOutOfService();
+			} finally {
+				// cleanly closing everything...
+				this.close();
+				//disableIfNeeded();
+				//BlueetoothGpsManager.instance.startConnectThread();
+			}
+						
+		}
+
+		class ReaderTask implements Callable<String> {
+			public BufferedReader reader;
+			
+			public ReaderTask(BufferedReader reader){
+				this.reader = reader;
+			}
+		    @Override
+		    public String call() throws Exception {
+		    	//reader
+		    	return reader.readLine();
+		    }
+		}		
+		
+		public void close(){
+			//playSound(R.raw.bluetooth_disconnected);			
+			
+			ready = false;
+			try {
+	        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "closing Bluetooth GPS output sream");
+				gpsInputStream.close();
+			} catch (IOException e) {
+				SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while closing GPS NMEA output stream", e);
+			} finally {
+				try {
+		        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "closing Bluetooth GPS socket");
+					socket.close();
+				} catch (IOException e) {
+					SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while closing GPS socket", e);
+				}
+			}
+		}
+	}
+
+	private Context context;
+	private BluetoothSocket gpsSocket;
+	private String gpsDeviceAddress;
+	private NmeaParser parser = new NmeaParser(10f);
+	private boolean enabled = false;
+	private ScheduledExecutorService connectionAndReadingPool;
+	private ConnectedGps connectedGps;
+	private int disableReason = 0;
+
+	private int maxConnectionRetries;
+	private int nbRetriesRemaining;
+	private boolean connected = false;
+	private BluetoothAdapter bluetoothAdapter = null;
+	private BluetoothDevice gpsDevice = null;
+	/**
+	 * @param context
+	 * @param deviceAddress
+	 * @param maxRetries
+	 */
+	public ClassicBluetoothGpsManager(Context context, String deviceAddress, int maxRetries) {
+		this.context = context;
+		ClassicBluetoothGpsManager.instance = this;
+		this.gpsDeviceAddress = deviceAddress;
+		this.maxConnectionRetries = maxRetries;
+		this.nbRetriesRemaining = 1+maxRetries;
+	}
+
+	private void setDisableReason(int reasonId){
+		disableReason = reasonId;
+	}
+	
+	/**
+	 * @return
+	 */
+	@Override
+	public int getDisableReason(){
+		return disableReason;
+	}
+	
+	/**
+	 * @return true if the bluetooth GPS is enabled
+	 */
+	@Override
+	public synchronized boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * Enables the bluetooth GPS Provider.
+	 * @return
+	 */
+	@Override
+	public synchronized boolean enable() {
+		//notificationManager.cancel(R.string.service_closed_because_connection_problem_notification_title);
+		if (! enabled){
+        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "enabling Bluetooth GPS manager");
+			bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+	        if (bluetoothAdapter == null) {
+	            // Device does not support Bluetooth
+				Toast.makeText(context,
+						"Device does not support Bluetooth",
+						Toast.LENGTH_SHORT).show();
+	        	SharedHolder.getInstance().getLogs().e(LOG_TAG, "Device does not support Bluetooth");
+	        	disable(R.string.msg_bluetooth_unsupported);
+	        } else if (!bluetoothAdapter.isEnabled()) {
+	        	// Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+	        	// startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+				Toast.makeText(context,
+						"Bluetooth is not enabled",
+						Toast.LENGTH_SHORT).show();
+
+	        	SharedHolder.getInstance().getLogs().e(LOG_TAG, "Bluetooth is not enabled");
+	        	disable(R.string.msg_bluetooth_disabled);
+	        } else {
+				gpsDevice = bluetoothAdapter.getRemoteDevice(gpsDeviceAddress);
+				if (gpsDevice == null){
+					SharedHolder.getInstance().getLogs().e(LOG_TAG, "GPS device not found");       	    	
+		        	disable(R.string.msg_bluetooth_gps_unavaible);
+				} else {
+	    			SharedHolder.getInstance().getLogs().v(LOG_TAG, "current device: "+gpsDevice.getName() + " -- " + gpsDevice.getAddress());
+					try {
+						gpsSocket = gpsDevice.createRfcommSocketToServiceRecord(UUID.fromString("00001101-0000-1000-8000-00805F9B34FB"));
+					} catch (IOException e) {
+	    				SharedHolder.getInstance().getLogs().e(LOG_TAG, "Error during connection", e);
+	    				gpsSocket = null;
+					}
+					if (gpsSocket == null){
+	    				SharedHolder.getInstance().getLogs().e(LOG_TAG, "Error while establishing connection: no socket");
+			        	disable(R.string.msg_bluetooth_gps_unavaible);
+					} else {
+						this.enabled = true;
+			        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "Bluetooth GPS manager enabled");
+			        	SharedHolder.getInstance().getLogs().v(LOG_TAG, "starting notification thread");
+						//notificationPool = Executors.newSingleThreadExecutor();
+			        	SharedHolder.getInstance().getLogs().v(LOG_TAG, "starting connection and reading thread");
+						connectionAndReadingPool = Executors.newSingleThreadScheduledExecutor();
+
+						startConnectThread();
+						Toast.makeText(context,
+								"Blue GPS started",
+								Toast.LENGTH_SHORT).show();
+						
+					}
+				}
+			}
+		}
+		return this.enabled;
+	}
+
+	@Override
+	public void startConnectThread() {
+		Runnable connectThread = new Runnable() {							
+			@Override
+			public void run() {
+				do
+				{
+					tryConnect(bluetoothAdapter, gpsDevice);
+				} while(!connected);
+			}
+		};
+		SharedHolder.getInstance().getLogs().v(LOG_TAG, "starting connection to socket task");
+		connectionAndReadingPool.scheduleWithFixedDelay(connectThread, 1000, 1000, TimeUnit.MILLISECONDS);
+	}
+	
+	
+	private void tryConnect(final BluetoothAdapter bluetoothAdapter,
+			final BluetoothDevice gpsDevice) {
+		try {
+			connected = false;
+			SharedHolder.getInstance().getLogs().v(LOG_TAG, "current device: "+gpsDevice.getName() + " -- " + gpsDevice.getAddress());
+			if ((bluetoothAdapter.isEnabled()) && (nbRetriesRemaining > 0 )){										
+				try {
+					if (connectedGps != null){
+						connectedGps.close();
+					}
+					if ((gpsSocket != null) && ((connectedGps == null) || (connectedGps.socket != gpsSocket))){
+						SharedHolder.getInstance().getLogs().d(LOG_TAG, "trying to close old socket");
+						gpsSocket.close();
+					}
+				} catch (IOException e) {
+					SharedHolder.getInstance().getLogs().e(LOG_TAG, "Error during disconnection", e);
+				}
+				try {
+					gpsSocket = gpsDevice.createRfcommSocketToServiceRecord(UUID.fromString("00001101-0000-1000-8000-00805F9B34FB"));
+				} catch (IOException e) {
+					SharedHolder.getInstance().getLogs().e(LOG_TAG, "Error during connection", e);
+					gpsSocket = null;
+				}
+				if (gpsSocket == null){
+					SharedHolder.getInstance().getLogs().e(LOG_TAG, "Error while establishing connection: no socket");
+		        	disable(R.string.msg_bluetooth_gps_unavaible);
+				} else {
+					// Cancel discovery because it will slow down the connection
+					bluetoothAdapter.cancelDiscovery();
+					// we increment the number of connection tries
+					// Connect the device through the socket. This will block
+					// until it succeeds or throws an exception
+					SharedHolder.getInstance().getLogs().v(LOG_TAG, "connecting to socket");
+					gpsSocket.connect();
+					SharedHolder.getInstance().getLogs().d(LOG_TAG, "connected to socket");
+					connected = true;
+					// reset eventual disabling cause
+//											setDisableReason(0);
+					// connection obtained so reset the number of connection try
+					nbRetriesRemaining = 1+maxConnectionRetries ;
+					//notificationManager.cancel(R.string.connection_problem_notification_title);
+					SharedHolder.getInstance().getLogs().v(LOG_TAG, "starting socket reading task");
+					connectedGps = new ConnectedGps(gpsSocket);
+					
+					connectionAndReadingPool.execute(connectedGps);					
+		        	SharedHolder.getInstance().getLogs().v(LOG_TAG, "socket reading thread started");
+				}
+			}
+		} catch (IOException connectException) {
+			// Unable to connect
+			Sounds.gps_disconnected.start();
+			SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while connecting to socket", connectException);									
+			// disable(R.string.msg_bluetooth_gps_unavaible);
+		} finally {
+			nbRetriesRemaining--;
+			if (! connected) {
+				disableIfNeeded();
+			}
+		}
+	}	
+
+	/**
+	 * Disables the bluetooth GPS Provider if the maximal number of connection retries is exceeded.
+	 * This is used when there are possibly non fatal connection problems. 
+	 * In these cases the provider will try to reconnect with the bluetooth device 
+	 * and only after a given retries number will give up and shutdown the service.
+	 */
+	private synchronized void disableIfNeeded(){
+		if (enabled){
+			if (nbRetriesRemaining > 0){
+				SharedHolder.getInstance().getLogs().e(LOG_TAG, "Unable to establish connection");
+			} else {
+				disable(R.string.msg_two_many_connection_problems);
+			}
+		}
+	}
+	
+	/**
+	 * Disables the bluetooth GPS provider.
+	 * 
+	 * It will: 
+	 * <ul>
+	 * 	<li>close the connection with the bluetooth device</li>
+	 * 	<li>disable the Mock Location Provider used for the bluetooth GPS</li>
+	 * 	<li>stop the BlueGPS4Droid service</li>
+	 * </ul>
+	 * The reasonId parameter indicates the reason to close the bluetooth provider. 
+	 * If its value is zero, it's a normal shutdown (normally, initiated by the user).
+	 * If it's non-zero this value should correspond a valid localized string id (res/values..../...) 
+	 * which will be used to display a notification.
+	 * 
+	 * @param reasonId	the reason to close the bluetooth provider.
+	 */
+	@Override
+	public synchronized void disable(int reasonId) {
+    	//SharedHolder.getInstance().getLogs().d(LOG_TAG, "disabling Bluetooth GPS manager reason: "+callingService.getString(reasonId));
+		setDisableReason(reasonId);
+    	disable(false);
+	}
+		
+	/**
+	 * Disables the bluetooth GPS provider.
+	 * 
+	 * It will: 
+	 * <ul>
+	 * 	<li>close the connection with the bluetooth device</li>
+	 * 	<li>disable the Mock Location Provider used for the bluetooth GPS</li>
+	 * 	<li>stop the BlueGPS4Droid service</li>
+	 * </ul>
+	 * If the bluetooth provider is closed because of a problem, a notification is displayed.
+	 */
+	@Override
+	public synchronized void disable(final boolean restart) {
+		if (enabled){
+        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "disabling Bluetooth GPS manager");
+			enabled = false;
+			connectionAndReadingPool.shutdown();
+
+			try {
+				connectionAndReadingPool.awaitTermination(1, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+			if (!connectionAndReadingPool.isTerminated()){
+				connectionAndReadingPool.shutdownNow();
+				if (connectedGps != null){
+					connectedGps.close();
+				}
+				if ((gpsSocket != null) && ((connectedGps == null) || (connectedGps.socket != gpsSocket))){
+					try {
+						SharedHolder.getInstance().getLogs().d(LOG_TAG, "closing Bluetooth GPS socket");
+						gpsSocket.close();
+					} catch (IOException closeException) {
+						SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while closing socket", closeException);
+					}
+				}
+			}
+			if(restart)
+			{
+				enable();
+			}
+
+        	SharedHolder.getInstance().getLogs().d(LOG_TAG, "Bluetooth GPS manager disabled");
+		}
+	}
+
+
+	/**
+	 * Notifies the reception of a NMEA sentence from the bluetooth GPS to registered NMEA listeners.
+	 * 
+	 * @param nmeaSentence	the complete NMEA sentence received from the bluetooth GPS (i.e. $....*XY where XY is the checksum)
+	 */
+	private void notifyNmeaSentence(final String nmeaSentence){
+		if (enabled){
+			NmeaValues nmeaValues = null;
+			try {
+				nmeaValues = parser.parseNmeaSentence(nmeaSentence);
+			} catch (Exception e){				
+		       	SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while parsing NMEA sentence: "+nmeaSentence, e);
+		       	nmeaValues = null;
+		       	Sounds.gps_disconnected.start();
+			}
+
+			if(nmeaValues != null && nmeaValues.getCommand() != null &&  nmeaValues.getCommand().equals("GPGGA")){
+		       	SharedHolder.getInstance().getLogs().v(LOG_TAG, nmeaSentence);
+			    setChanged();
+			    notifyObservers(nmeaValues);
+			}
+		}
+	}
+	
+}

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/ClassicBluetoothGpsManager.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/bluetooth/provider/ClassicBluetoothGpsManager.java
@@ -154,9 +154,9 @@ public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
 							e.printStackTrace();
 						}
 				        
-				        if(sentenseStr != ""){
+				        if(enabled && sentenseStr != null && !sentenseStr.isEmpty()){
 							//SharedHolder.getInstance().getLogs().v(LOG_TAG, "data: "+System.currentTimeMillis()+" "+s);
-							notifyNmeaSentence(sentenseStr + "\r\n");
+							notifyNmeaSentence(sentenseStr);
 				        }
 						lastRead = SystemClock.uptimeMillis();
 					} else {
@@ -227,7 +227,6 @@ public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
 	private Context context;
 	private BluetoothSocket gpsSocket;
 	private String gpsDeviceAddress;
-	private NmeaParser parser = new NmeaParser(10f);
 	private boolean enabled = false;
 	private ScheduledExecutorService connectionAndReadingPool;
 	private ConnectedGps connectedGps;
@@ -276,7 +275,7 @@ public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
 	 * @return
 	 */
 	@Override
-	public synchronized boolean enable() {
+	public synchronized void enable() {
 		//notificationManager.cancel(R.string.service_closed_because_connection_problem_notification_title);
 		if (! enabled){
         	SharedHolder.getInstance().getLogs().d(LOG_TAG, "enabling Bluetooth GPS manager");
@@ -330,10 +329,8 @@ public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
 				}
 			}
 		}
-		return this.enabled;
 	}
 
-	@Override
 	public void startConnectThread() {
 		Runnable connectThread = new Runnable() {							
 			@Override
@@ -496,28 +493,4 @@ public class ClassicBluetoothGpsManager extends BluetoothGpsManager {
 	}
 
 
-	/**
-	 * Notifies the reception of a NMEA sentence from the bluetooth GPS to registered NMEA listeners.
-	 * 
-	 * @param nmeaSentence	the complete NMEA sentence received from the bluetooth GPS (i.e. $....*XY where XY is the checksum)
-	 */
-	private void notifyNmeaSentence(final String nmeaSentence){
-		if (enabled){
-			NmeaValues nmeaValues = null;
-			try {
-				nmeaValues = parser.parseNmeaSentence(nmeaSentence);
-			} catch (Exception e){				
-		       	SharedHolder.getInstance().getLogs().e(LOG_TAG, "error while parsing NMEA sentence: "+nmeaSentence, e);
-		       	nmeaValues = null;
-		       	Sounds.gps_disconnected.start();
-			}
-
-			if(nmeaValues != null && nmeaValues.getCommand() != null &&  nmeaValues.getCommand().equals("GPGGA")){
-		       	SharedHolder.getInstance().getLogs().v(LOG_TAG, nmeaSentence);
-			    setChanged();
-			    notifyObservers(nmeaValues);
-			}
-		}
-	}
-	
 }

--- a/rocketlocator/src/main/java/org/broeuschmeul/android/gps/nmea/util/NmeaParser.java
+++ b/rocketlocator/src/main/java/org/broeuschmeul/android/gps/nmea/util/NmeaParser.java
@@ -51,6 +51,14 @@ public class NmeaParser {
 	 */
 	private static final String LOG_TAG = "BlueGPS";
 
+	// GP: GPS, GN: GALILEO, GL: GLONASS, GA: multi
+	private static final String POS_PREFIX_REGEX = "G[PNLA]";
+	private static final Pattern GGA = Pattern.compile(POS_PREFIX_REGEX + "GGA");
+	private static final Pattern RMC = Pattern.compile(POS_PREFIX_REGEX + "RMC");
+	private static final Pattern GSA = Pattern.compile(POS_PREFIX_REGEX + "GSA");
+	private static final Pattern VTG = Pattern.compile(POS_PREFIX_REGEX + "VTG");
+	private static final Pattern GLL = Pattern.compile(POS_PREFIX_REGEX + "GLL");
+
 	private boolean hasGGA = false;
 	private boolean hasRMC = false;
 	private float precision = 10f;
@@ -84,7 +92,7 @@ public class NmeaParser {
 			SimpleStringSplitter splitter = new SimpleStringSplitter(',');
 			splitter.setString(sentence);
 			command = splitter.next();
-			if (command.equals("GPGGA")){
+			if (GGA.matcher(command).matches()) {
 				if(!Sounds.gps_connected.isPlaying()){
 					Sounds.pulse.start();
 				}
@@ -183,7 +191,7 @@ public class NmeaParser {
 						notifyStatusChanged(LocationProvider.TEMPORARILY_UNAVAILABLE, null, updateTime);
 					}	*/			
 				}
-			} else if (command.equals("GPRMC")){
+			} else if (RMC.matcher(command).matches()) {
 				/* $GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A
 	
 				   Where:
@@ -246,7 +254,7 @@ public class NmeaParser {
 						notifyStatusChanged(LocationProvider.TEMPORARILY_UNAVAILABLE, null, updateTime);
 					}*/				
 				}		
-			} else if (command.equals("GPGSA")){
+			} else if (GSA.matcher(command).matches()) {
 				/*  $GPGSA,A,3,04,05,,09,12,,,24,,,,,2.5,1.3,2.1*39
 	
 					Where:
@@ -275,7 +283,7 @@ public class NmeaParser {
 				String hdop = splitter.next();
 				// Vertical dilution of precision (float)
 				String vdop = splitter.next();			
-			} else if (command.equals("GPVTG")){
+			} else if (VTG.matcher(command).matches()) {
 				/*  $GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*48
 					
 					where:
@@ -304,7 +312,7 @@ public class NmeaParser {
 				splitter.next();
 				// for NMEA 0183 version 3.00 active the Mode indicator field is added
 				// Mode indicator, (A=autonomous, D=differential, E=Estimated, N=not valid, S=Simulator )
-			} else if (command.equals("GPGLL")){
+			} else if (GLL.matcher(command).matches()) {
 				/*  $GPGLL,4916.45,N,12311.12,W,225444,A,*1D
 					
 					Where:

--- a/rocketlocator/src/main/res/layout/listitem_device.xml
+++ b/rocketlocator/src/main/res/layout/listitem_device.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/device_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        android:textSize="24sp"
+        tools:text="DeviceName" />
+
+    <TextView
+        android:id="@+id/device_address"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="5dp"
+        android:paddingEnd="5dp"
+        android:textSize="12sp"
+        tools:text="abcdef12345" />
+</LinearLayout>

--- a/rocketlocator/src/main/res/values/constants.xml
+++ b/rocketlocator/src/main/res/values/constants.xml
@@ -23,6 +23,7 @@
 
     <string name="pref_measure_units_key">measureUnit</string>
     <string name="pref_bluetooth_device_key">bluetoothDevice</string>
+    <string name="pref_use_ble_key">ble</string>
     <string name="pref_about_key">about</string>
     <string name="pref_logs_enabled_key">logsEnabled</string>
     <string name="defaultLogFileDirectory">/sdcard/rocketlocator</string>

--- a/rocketlocator/src/main/res/values/constants.xml
+++ b/rocketlocator/src/main/res/values/constants.xml
@@ -25,6 +25,7 @@
     <string name="pref_bluetooth_device_key">bluetoothDevice</string>
     <string name="pref_use_ble_key">ble</string>
     <string name="pref_about_key">about</string>
+    <string name="pref_external_cache_key">externalCache</string>
     <string name="pref_logs_enabled_key">logsEnabled</string>
     <string name="defaultLogFileDirectory">/sdcard/rocketlocator</string>
 

--- a/rocketlocator/src/main/res/values/strings.xml
+++ b/rocketlocator/src/main/res/values/strings.xml
@@ -37,5 +37,6 @@
     <string name="provider_baseUrl_google">https://mt.google.com/vt/lyrs=y&amp;x={x}&amp;y={y}&amp;z={z}</string>
     <string name="provider_baseUrl_osm">https://a.tile.openstreetmap.org/{z}/{x}/{y}.png</string>
     <string name="menu_download_map">Download Map</string>
+    <string name="external_cache">Store map cache in external dir</string>
 
 </resources>

--- a/rocketlocator/src/main/res/values/strings.xml
+++ b/rocketlocator/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="menu_random_pos">Random pos</string>
     <string name="menu_reset_altitude">Reset altitude</string>
     <string name="pref_logs_enabled_title">Enable log to file</string>
+    <string name="pref_use_ble_title">Use Bluetooth LE</string>
     <string name="pref_bluetooth_device_title">Bluetooth Device</string>
     <string name="pref_bluetooth_device_summary">"Actual Device : %s"</string>
     <string name="pref_about_title">About</string>

--- a/rocketlocator/src/main/res/xml/pref.xml
+++ b/rocketlocator/src/main/res/xml/pref.xml
@@ -2,13 +2,11 @@
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:title="@string/app_name" >
-	<ListPreference 
+	<com.frankdev.rocketlocator.BleListPreference
 		android:dialogTitle="@string/pref_bluetooth_device_title"
 		android:title="@string/pref_bluetooth_device_title" 
 		android:key="@string/pref_bluetooth_device_key" 	
-		android:summary="@string/pref_bluetooth_device_summary"
-		android:entries="@array/measure_units_entries"
-		android:entryValues="@array/measure_units_entries"/>
+		android:summary="@string/pref_bluetooth_device_summary" />
 	<ListPreference
 		android:dialogTitle="@string/pref_measure_units_title"
 		android:title="@string/pref_measure_units_title"

--- a/rocketlocator/src/main/res/xml/pref.xml
+++ b/rocketlocator/src/main/res/xml/pref.xml
@@ -20,7 +20,11 @@
 		android:defaultValue="metric" />
     <CheckBoxPreference
             android:key="@string/pref_logs_enabled_key"
-            android:title="@string/pref_logs_enabled_title" />	
+            android:title="@string/pref_logs_enabled_title" />
+	<CheckBoxPreference
+		android:key="@string/pref_external_cache_key"
+		android:title="@string/external_cache"
+		android:defaultValue="false" />
 	<Preference
 		android:key="@string/pref_about_key"
 		android:persistent="false"

--- a/rocketlocator/src/main/res/xml/pref.xml
+++ b/rocketlocator/src/main/res/xml/pref.xml
@@ -2,7 +2,10 @@
 <PreferenceScreen
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	android:title="@string/app_name" >
-	<com.frankdev.rocketlocator.BleListPreference
+    <CheckBoxPreference
+        android:title="@string/pref_use_ble_title"
+        android:key="@string/pref_use_ble_key" />
+    <com.frankdev.rocketlocator.BleListPreference
 		android:dialogTitle="@string/pref_bluetooth_device_title"
 		android:title="@string/pref_bluetooth_device_title" 
 		android:key="@string/pref_bluetooth_device_key" 	

--- a/rocketlocator/src/main/res/xml/pref.xml
+++ b/rocketlocator/src/main/res/xml/pref.xml
@@ -5,7 +5,7 @@
     <CheckBoxPreference
         android:title="@string/pref_use_ble_title"
         android:key="@string/pref_use_ble_key" />
-    <com.frankdev.rocketlocator.BleListPreference
+    <com.frankdev.rocketlocator.BluetoothListPreference
 		android:dialogTitle="@string/pref_bluetooth_device_title"
 		android:title="@string/pref_bluetooth_device_title" 
 		android:key="@string/pref_bluetooth_device_key" 	

--- a/rocketlocator/src/test/java/org/broeuschmeul/android/gps/bluetooth/provider/NmeaInputMergerTest.java
+++ b/rocketlocator/src/test/java/org/broeuschmeul/android/gps/bluetooth/provider/NmeaInputMergerTest.java
@@ -1,0 +1,66 @@
+package org.broeuschmeul.android.gps.bluetooth.provider;
+
+import android.support.v4.util.Consumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NmeaInputMergerTest {
+
+    private static final String NMEA = "$GPGGA,114919.000,4712.4294,N,01815.2761,E,1,04,3.7,178.3,M,0.0,M,,*60";
+
+    @Mock
+    private Consumer<String> mockConsumer;
+
+    private BleBluetoothGpsManager.NmeaInputMerger merger = new BleBluetoothGpsManager.NmeaInputMerger();
+
+    @Test
+    public void testHandleMessagePartSingleStart() {
+        merger.handleMessagePart(NMEA, mockConsumer);
+        // only the next message triggers an action
+        merger.handleMessagePart("$GPnext", mockConsumer);
+        verify(mockConsumer).accept(eq(NMEA));
+    }
+
+    @Test
+    public void testHandleMessagePartSingleMiddle() {
+        merger.handleMessagePart("something", mockConsumer);
+        // add extra line break too - it should be skipped
+        merger.handleMessagePart(NMEA + "\n", mockConsumer);
+        // only the next message triggers an action
+        merger.handleMessagePart("$GPnext", mockConsumer);
+        verify(mockConsumer).accept(eq("something"));
+        verify(mockConsumer).accept(eq(NMEA));
+    }
+
+    @Test
+    public void testHandleMessagePartMultiStart() {
+        String[] nmeaParts = { "$GPGGA,114919.000,47", "12.4294,N,01815.2761", ",E,1,04,3.7,178.3,M,", "0.0,M,,*60" };
+        for (String nmeaPart : nmeaParts) {
+            merger.handleMessagePart(nmeaPart, mockConsumer);
+        }
+        // only the next message triggers an action
+        merger.handleMessagePart("$GPnext", mockConsumer);
+        verify(mockConsumer).accept(eq(NMEA));
+    }
+
+    @Test
+    public void testHandleMessagePartMultiMiddle() {
+        String[] nmeaParts = { "$GPGGA,114919.000,47", "12.4294,N,01815.2761", ",E,1,04,3.7,178.3,M,", "0.0,M,,*60" };
+        merger.handleMessagePart("something", mockConsumer);
+        for (String nmeaPart : nmeaParts) {
+            merger.handleMessagePart(nmeaPart, mockConsumer);
+        }
+        // only the next message triggers an action
+        merger.handleMessagePart("$GPnext", mockConsumer);
+        verify(mockConsumer).accept(eq("something"));
+        verify(mockConsumer).accept(eq(NMEA));
+    }
+
+}


### PR DESCRIPTION
- a new option is added to settings (enabled only for API 19+): "Use Blouetooth LE"
  - if this option is enabled Bluetooth LE devices will be scanned on-the-fly when opening the "Bluetooth Device" dialog (when disabled the paired classic devices will be shown like before)
- a Bluetooth LE GPS manager was implemented to handle incoming NMEA "notifications" through the custom (general purpose) FFE0 GATT service
  - an abstract BluetoothGpsManager was extracted, "Classic" and "Ble" override this
- improved NMEA parser to handle GALILEO, GLONASS and multi provider too
- store the tile cache as ".dat" files instead of ".png" so the Album/Photos apps won't display these
- use the standard cache folder for the tile cache by default
  - new setting added to use the external cache folder if necessary
  - by using the standard cache the system can delete files when necessary (or the user can empty the cache manually in the app settings)
- gradle version was increased